### PR TITLE
basic ui implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>nz.net.ultraq.thymeleaf</groupId>
+			<artifactId>thymeleaf-layout-dialect</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>CinciAlert</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+</head>
+<body class="m-0 border-0 bd-example m-0 border-0 bg-body-secondary">
+<nav class="navbar fixed-top navbar-expand-lg navbar-light bg-light">
+    <div class="container-fluid">
+        <a class="navbar-brand" th:href="@{/}">CinciAlert</a>
+        <button
+                class="navbar-toggler"
+                type="button"
+                data-bs-toggle="collapse"
+                data-bs-target="#navbarNav"
+                aria-controls="navbarNav"
+                aria-expanded="false"
+                aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse text-center" id="navbarNav">
+            <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                <li class="nav-item mx-4">
+                    <a class="nav-link" aria-current="page" th:href="@{/signup}">Signup</a>
+                </li>
+                <li class="nav-item mx-4">
+                    <a class="nav-link" aria-current="page" th:href="@{/login}">Login</a>
+                </li>
+                <li class="nav-item mx-4">
+                    <a class="nav-link" aria-current="page" th:href="@{/traffic}">Traffic</a>
+                </li>
+            </ul>
+        </div>
+    </div>
+</nav>
+<div layout:fragment="content">
+    <p>loading...</p>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js" integrity="sha384-I7E8VVD/ismYTF4hNIPjVp/Zjvgyol6VFvRkX/vR+Vc4jQkC+hVqc2pM8ODewa9r" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/src/main/resources/templates/traffic.html
+++ b/src/main/resources/templates/traffic.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout}">
+<head>
+    <meta charset="UTF-8">
+    <title>CinciAlert</title>
+</head>
+<body>
+<div layout:fragment="content">
+    <div class="d-flex flex-column min-vh-100 justify-content-center align-items-center">
+        <h1>CinciAlert</h1>
+        <p><i>This is a placeholder for the traffic page.</i></p>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
### Technical Suggestions:

#### added thymeleaf dialect to pom.xml
https://github.com/dappensd/Enterprise-App-Development---Group-1/commit/934771c3c8314366d7b624ffd191b75c20d21704

For this commit I added thymeleaf dialect package to pom.xml. I think this would be a good idea to add because it allows for greater code reusability and provides you with the ability to utilize layouts and "components" for your site.

#### added example layout page w/ bootstrap
https://github.com/dappensd/Enterprise-App-Development---Group-1/commit/89e3bd39eae2e7cb3f68e980e623b3d5d93398ef

I suggest using a UI kit such as bootstrap and creating a central "layout" page that will wrap the other pages of your application. There are multiple reasons to do this. Firstly, modern web applications need to be responsive so they are accessible to users on many different types of devices. Secondly, most web applications do not need to waste time on reinventing the wheel - there are many UI kits that we can use that have already been designed to be responsive, accessible to people with disabilities, etc. To design our buttons, navigation, etc with all of these things in mind from the ground up would take a long time and would probably not end up as good as a lot of the stuff out there that already exists.

#### created traffic page using dialect
https://github.com/dappensd/Enterprise-App-Development---Group-1/commit/fc67a081a509a806c0f43cfb38918fc2fc9cef54

Lastly I added a "traffic" page that utilizes the layout page & thymeleaf dialect features. I created the page "traffic" since I noticed that your site mockups seemed to indicate that there would be a page like this that would display the traffic incidents with Google Maps API and that the only current pages that existed in the project were "home", "signup" and "login".

**To implement the changes I have made correctly, you would need to replace the home, signup, and login pages to be set up just like the traffic page that I have added.**